### PR TITLE
fix "Security Policy" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html.
 
 ## Policies
 
-- [Security policy](.github/SECURITY.md)
+- [Security policy](SECURITY.md)
 - [Contribution policy](CONTRIBUTING.md)
 
 ## License


### PR DESCRIPTION
This PR fixes the incorrect link to SECURITY.md in READ.me.