### PR TITLE
implement CUDA version check during build

### DIFF
--- a/boojum-cuda/Cargo.toml
+++ b/boojum-cuda/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [build-dependencies]
 boojum = { git = "https://github.com/matter-labs/era-boojum.git", branch = "main" }
+cudart-sys = { path = "../cudart-sys" }
 cmake = "^0"
 itertools = "^0"
 

--- a/boojum-cuda/build/main.rs
+++ b/boojum-cuda/build/main.rs
@@ -1,6 +1,8 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
+use cudart_sys::{cuda_lib_path, cuda_path};
+
 mod gates;
 mod poseidon_constants;
 mod template;
@@ -19,13 +21,7 @@ fn main() {
         .build();
     println!("cargo:rustc-link-search=native={}", dst.display());
     println!("cargo:rustc-link-lib=static=boojum-cuda-native");
-    #[cfg(target_os = "windows")]
-    println!(
-        "cargo:rustc-link-search=native={}",
-        concat!(env!("CUDA_PATH"), "/lib/x64")
-    );
-    #[cfg(target_os = "linux")]
-    println!("cargo:rustc-link-search=native=/usr/local/cuda/lib");
+    println!("cargo:rustc-link-search=native={}", cuda_lib_path!());
     println!("cargo:rustc-link-lib=cudart");
     #[cfg(target_os = "linux")]
     println!("cargo:rustc-link-lib=stdc++");

--- a/cudart-sys/Cargo.toml
+++ b/cudart-sys/Cargo.toml
@@ -6,3 +6,4 @@ license = "MIT OR Apache-2.0"
 
 [build-dependencies]
 bindgen = "^0"
+serde_json = "^1"

--- a/cudart-sys/src/lib.rs
+++ b/cudart-sys/src/lib.rs
@@ -2,6 +2,8 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+mod path;
+
 use std::backtrace::Backtrace;
 use std::error::Error;
 use std::ffi::CStr;

--- a/cudart-sys/src/path.rs
+++ b/cudart-sys/src/path.rs
@@ -1,0 +1,54 @@
+#[cfg(target_os = "windows")]
+#[macro_export]
+macro_rules! cuda_path {
+    () => {
+        env!("CUDA_PATH")
+    };
+}
+
+#[cfg(target_os = "linux")]
+#[macro_export]
+macro_rules! cuda_path {
+    () => {
+        "/usr/local/cuda"
+    };
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+#[macro_export]
+macro_rules! cuda_path {
+    () => {
+        unimplemented!()
+    };
+}
+
+#[macro_export]
+macro_rules! cuda_include_path {
+    () => {
+        concat!(cuda_path!(), "/include")
+    };
+}
+
+#[cfg(target_os = "windows")]
+#[macro_export]
+macro_rules! cuda_lib_path {
+    () => {
+        concat!(cuda_path!(), "/lib/x64")
+    };
+}
+
+#[cfg(target_os = "linux")]
+#[macro_export]
+macro_rules! cuda_lib_path {
+    () => {
+        concat!(cuda_path!(), "/lib64")
+    };
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+#[macro_export]
+macro_rules! cuda_lib_path {
+    () => {
+        unimplemented!()
+    };
+}


### PR DESCRIPTION
# What ❔

This PR implements a CUDA version check during build and refactors build scripts using CUDA path macros

## Why ❔

The implemented check produces a descriptive error message in case the code is compiled with an incompatible CUDA version instead of failing with some generic CUDA compilation error.