### PR TITLE
add @matter-labs/devops to CODEOWNERS file as the owner of /.github/workflows/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @robik75 @mcarilli
+/.github/workflows/ @matter-labs/devops


### PR DESCRIPTION
…orkflows/

# What ❔

This PR adds @matter-labs/devops to CODEOWNERS file as the owner of `/.github/workflows/`

## Why ❔

Contents of `/.github/workflows/` are managed by DevOps.
