### PR TITLE
make the code compatible with CUDA 12.3

### DIFF
--- a/cudart/src/execution.rs
+++ b/cudart/src/execution.rs
@@ -108,6 +108,8 @@ impl CudaLaunchAttribute {
                     Self::MemSyncDomainMap(value.memSyncDomainMap)
                 }
                 CudaLaunchAttributeID::MemSyncDomain => Self::MemSyncDomain(value.memSyncDomain),
+                #[allow(unreachable_patterns)]
+                _ => unimplemented!("Unsupported CudaLaunchAttributeID"),
             }
         }
     }


### PR DESCRIPTION
# What ❔

This code implements the changes necessary to make it compile with CUDA 12.3.

## Why ❔

CUDA 12.3 introduced a new `CudaLaunchAttributeID` named `LaunchCompletionEvent`, a default match arm is needed to make the code compile with CUDA 12.3 but also previous CUDA versions.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
