### PR TITLE
fix latest linter warnings

### DIFF
--- a/boojum-cuda/src/barycentric.rs
+++ b/boojum-cuda/src/barycentric.rs
@@ -91,6 +91,7 @@ pub trait PrecomputeImpl {
         GoldilocksField,
         u32,
     );
+    #[allow(clippy::type_complexity)]
     fn get_precompute_kernel() -> unsafe extern "C" fn(
         *const <Self::X as DeviceRepr>::Type,
         *const <Self::X as DeviceRepr>::Type,
@@ -181,6 +182,7 @@ pub trait EvalImpl {
     type XVec: DeviceRepr;
     type YsVec: DeviceRepr;
     fn get_partial_reduce_elems_per_thread() -> u32;
+    #[allow(clippy::type_complexity)]
     fn get_partial_reduce_kernel() -> unsafe extern "C" fn(
         PtrAndStride<<Self::YsVec as DeviceRepr>::Type>,
         PtrAndStride<<Self::XVec as DeviceRepr>::Type>,

--- a/boojum-cuda/src/ops_cub/device_radix_sort.rs
+++ b/boojum-cuda/src/ops_cub/device_radix_sort.rs
@@ -591,14 +591,8 @@ mod tests {
         memory_copy_async(&mut h_keys_out, &d_keys_out, &stream).unwrap();
         memory_copy_async(&mut h_values_out, &d_values_out, &stream).unwrap();
         stream.synchronize().unwrap();
-        let mut pairs_in = h_keys_in
-            .into_iter()
-            .zip(h_values_in.into_iter())
-            .collect_vec();
-        let pairs_out = h_keys_out
-            .into_iter()
-            .zip(h_values_out.into_iter())
-            .collect_vec();
+        let mut pairs_in = h_keys_in.into_iter().zip(h_values_in).collect_vec();
+        let pairs_out = h_keys_out.into_iter().zip(h_values_out).collect_vec();
         pairs_in.sort_by_key(|(k, _)| k.clone());
         if descending {
             pairs_in.reverse()

--- a/boojum-cuda/src/ops_cub/device_scan.rs
+++ b/boojum-cuda/src/ops_cub/device_scan.rs
@@ -844,10 +844,10 @@ mod tests {
         h_in.into_iter()
             .chunks(NUM_ITEMS)
             .into_iter()
-            .zip(h_out.into_iter().chunks(NUM_ITEMS).into_iter())
+            .zip(h_out.chunks(NUM_ITEMS))
             .for_each(|(h_in, h_out)| {
                 let h_in = h_in.collect_vec();
-                let h_out = h_out.collect_vec();
+                let h_out = Vec::from(h_out);
                 verify(operation, inclusive, reverse, h_in, h_out);
             });
     }

--- a/cudart/src/execution.rs
+++ b/cudart/src/execution.rs
@@ -454,9 +454,9 @@ pub struct HostFn<'a> {
 }
 
 impl<'a> HostFn<'a> {
-    pub fn new(func: impl Fn() + Send + 'a) -> Self {
+    pub fn new(func: impl Fn() + Send + Sync + 'a) -> Self {
         Self {
-            arc: Arc::new(Box::new(func) as Box<dyn Fn() + Send>),
+            arc: Arc::new(Box::new(func) as Box<dyn Fn() + Send + Sync>),
         }
     }
 }


### PR DESCRIPTION
# What ❔

This PR fixes the linter (clippy) warnings that appeared with the latest rust toolchain version.

## Why ❔

Warnings are not nice.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt`
