### PR TITLE
Fix linter warning in poseidon test

### DIFF
--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -984,7 +984,7 @@ mod tests {
                 });
             if !results_next.is_empty() {
                 let indexes_next = indexes.iter().map(|&x| x >> 1).collect_vec();
-                verify_merkle_path(&indexes_next, &values_next, &results_next);
+                verify_merkle_path(&indexes_next, values_next, results_next);
             }
         }
         verify_merkle_path(&indexes_host, &values_host, &results_host);


### PR DESCRIPTION
# What ❔

This PR fixes a linter warning in one of the poseidon tests.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `cargo fmt` and linted with `cargo clippy`.
