### PR TITLE
bump rust toolchain and relax dependencies to fixed minor version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,15 +49,15 @@ jobs:
       - name: Setup rust
         run: |
           rustup set profile minimal
-          rustup toolchain install nightly-2023-06-25
-          rustup default nightly-2023-06-25
+          rustup toolchain install nightly-2023-08-21
+          rustup default nightly-2023-08-21
 
       - name: Build tests and copy binaries to a separate dir
         shell: bash
         run: |
           mkdir artifacts
           CUDAARCHS=80 CARGO_TARGET_DIR=./build \
-          cargo +nightly-2023-06-25 test --no-run --release --message-format=json -q \
+          cargo +nightly-2023-08-21 test --no-run --release --message-format=json -q \
           | jq -r 'select(.executable != null) | .executable' \
           | while read binary; do
             cp "$binary" artifacts/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
 [[package]]
 name = "criterion-cuda"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-cuda.git?branch=main#465d2acdfce49123f6334f5b43bf799962a4c77f"
+source = "git+https://github.com/matter-labs/era-cuda.git?branch=main#3ef61d56b84c1f877fe8aab6ec2b1d14a96cd671"
 dependencies = [
  "criterion",
  "cudart",
@@ -475,7 +475,7 @@ dependencies = [
 [[package]]
 name = "cudart"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-cuda.git?branch=main#465d2acdfce49123f6334f5b43bf799962a4c77f"
+source = "git+https://github.com/matter-labs/era-cuda.git?branch=main#3ef61d56b84c1f877fe8aab6ec2b1d14a96cd671"
 dependencies = [
  "bitflags 2.4.2",
  "cudart-sys",
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "cudart-sys"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-cuda.git?branch=main#465d2acdfce49123f6334f5b43bf799962a4c77f"
+source = "git+https://github.com/matter-labs/era-cuda.git?branch=main#3ef61d56b84c1f877fe8aab6ec2b1d14a96cd671"
 dependencies = [
  "bindgen",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,25 +8,25 @@ license = "MIT OR Apache-2.0"
 [build-dependencies]
 boojum = { git = "https://github.com/matter-labs/era-boojum.git", branch = "main" }
 cudart-sys = { git = "https://github.com/matter-labs/era-cuda.git", branch = "main", package = "cudart-sys" }
-cmake = "0.1.50"
-itertools = "0.12.1"
+cmake = "0.1"
+itertools = "0.12"
 
 [dependencies]
 boojum = { git = "https://github.com/matter-labs/era-boojum.git", branch = "main" }
 cudart = { git = "https://github.com/matter-labs/era-cuda.git", branch = "main", package = "cudart" }
 cudart-sys = { git = "https://github.com/matter-labs/era-cuda.git", branch = "main", package = "cudart-sys" }
-itertools = "0.12.1"
-lazy_static = "1.4.0"
+itertools = "0.12"
+lazy_static = "1.4"
 
 [dev-dependencies]
-blake2 = "0.10.6"
-criterion = "0.4.0"
+blake2 = "0.10"
+criterion = "0.4"
 criterion-cuda = { git = "https://github.com/matter-labs/era-cuda.git", branch = "main", package = "criterion-cuda" }
-criterion-macro = "0.4.0"
-itertools = "0.12.1"
-rand = "0.8.5"
-rayon = "1.8.1"
-serial_test = "3.0.0"
+criterion-macro = "0.4"
+itertools = "0.12"
+rand = "0.8"
+rayon = "1.8"
+serial_test = "3.0"
 
 [[bench]]
 name = "blake2s"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-06-25"
+channel = "nightly-2023-08-21"


### PR DESCRIPTION
# What ❔

This PR bumps the rust toolchain version tonightly-2023-08-21 and relaxes the dependency versions fix to minor version.

## Why ❔

The nightly-2023-08-21 is used by zksync-era repo so it makes sense to use the same version to make sure code in this repo compiles when used by zksync-era.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
