### PR TITLE
fix "missing return statement" compiler warnings

### DIFF
--- a/native/goldilocks.cuh
+++ b/native/goldilocks.cuh
@@ -66,6 +66,7 @@ template <unsigned LIMBS_COUNT> struct __align__(LIMBS_ALIGNMENT(LIMBS_COUNT)) f
       return {1, ~1u};
     default:
       static_assert(LIMBS_COUNT >= 2 && LIMBS_COUNT <= 4);
+      return {};
     }
   }
 
@@ -82,6 +83,7 @@ template <unsigned LIMBS_COUNT> struct __align__(LIMBS_ALIGNMENT(LIMBS_COUNT)) f
       return {flag & 1, flag & ~1};
     default:
       static_assert(LIMBS_COUNT >= 2 && LIMBS_COUNT <= 4);
+      return {};
     }
   }
 

--- a/native/memory.cuh
+++ b/native/memory.cuh
@@ -27,9 +27,8 @@ template <typename T, ld_modifier MODIFIER> static constexpr DEVICE_FORCEINLINE 
   case ld_modifier::cv:
     return __ldcv(ptr);
   }
-#else
-  return *ptr;
 #endif
+  return *ptr;
 }
 
 enum class st_modifier { none, wb, cg, cs, wt };
@@ -53,9 +52,8 @@ template <typename T, st_modifier MODIFIER> static constexpr DEVICE_FORCEINLINE 
     __stwt(ptr, value);
     break;
   }
-#else
-  *ptr = value;
 #endif
+  *ptr = value;
 }
 
 template <typename T> DEVICE_FORCEINLINE void swap(T &a, T &b) {


### PR DESCRIPTION
# What ❔

This PR fixes "missing return statement" compiler warnings.
